### PR TITLE
Align option help, long option names and README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,27 @@ linux-serial-test
       -h, --help
       -b, --baud        Baud rate, 115200, etc (115200 is default)
       -p, --port        Port (/dev/ttyS0, etc) (must be specified)
-      -d, --divisor     UART Baud rate divisor (can be used to set custom baud rates
+      -d, --divisor     UART Baud rate divisor (can be used to set custom baud rates)
       -R, --rx_dump     Dump Rx data (ascii, raw)
       -T, --detailed_tx Detailed Tx data
       -s, --stats       Dump serial port stats every 5s
-      -a, --timing-byte output a double 0x80 to the serial port for measuring bit timimg
-      -y, --single-bype send specified byte to the serial port 
-      -z, --second-bype send another specified byte to the serial port 
+      -S, --stop-on-err Stop program if we encounter an error
+      -y, --single-byte Send specified byte to the serial port
+      -z, --second-byte Send another specified byte to the serial port
+      -c, --rts-cts     Enable RTS/CTS flow control
+      -e, --dump-err    Display errors
+      -r, --no-rx       Don't receive data (can be used to test flow control)
+                        when serial driver buffer is full
+      -t, --no-tx       Don't transmit data
+      -q, --rs485       Enable RS485 direction control on port, and set delay
+                        from when TX is finished and RS485 driver enable is
+                        de-asserted. Delay is specified in bit times.
 
 # Examples
 
 ## Stress test a connection
 
-    linux-serial-test -s -p /dev/ttyO0 -b 3000000
+    linux-serial-test -s -e -p /dev/ttyO0 -b 3000000
 
 This will send full bandwidth data with a counting pattern out the TX signal.
 On any data received on RX, the program will look for a counting pattern and 

--- a/linux-serial-test.c
+++ b/linux-serial-test.c
@@ -135,22 +135,22 @@ void display_help()
 			"  -h, --help\n"
 			"  -b, --baud        Baud rate, 115200, etc (115200 is default)\n"
 			"  -p, --port        Port (/dev/ttyS0, etc) (must be specified)\n"
-			"  -d, --divisor     UART Baud rate divisor (can be used to set custom baud rates\n"
+			"  -d, --divisor     UART Baud rate divisor (can be used to set custom baud rates)\n"
 			"  -R, --rx_dump     Dump Rx data (ascii, raw)\n"
 			"  -T, --detailed_tx Detailed Tx data\n"
 			"  -s, --stats       Dump serial port stats every 5s\n"
 			"  -S, --stop-on-err Stop program if we encounter an error\n"
-			"  -y, --single-byte Send specified byte to the serial port \n"
-			"  -z, --second-byte Send another specified byte to the serial port \n"
-			"  -c, --rts-cts     Enable RTS/CTS flow control \n"
-			"  -e, --dump-err    Display errors \n"
-			"  -r, --no-rx       Don't receive data (can be used to test flow control\n"
-		        "                    when serial driver buffer is full\n"
+			"  -y, --single-byte Send specified byte to the serial port\n"
+			"  -z, --second-byte Send another specified byte to the serial port\n"
+			"  -c, --rts-cts     Enable RTS/CTS flow control\n"
+			"  -e, --dump-err    Display errors\n"
+			"  -r, --no-rx       Don't receive data (can be used to test flow control)\n"
+			"                    when serial driver buffer is full\n"
 			"  -t, --no-tx       Don't transmit data\n"
-			"  -l, --rx-delay    Delay between reading data (can be used to test flow control\n"
+			"  -l, --rx-delay    Delay between reading data (can be used to test flow control)\n"
 			"  -q, --rs485       Enable RS485 direction control on port, and set delay\n"
 			"                    from when TX is finished and RS485 driver enable is\n"
-			"                    de-asserted. Delay is specified in bit times (0-7)\n"
+			"                    de-asserted. Delay is specified in bit times.\n"
 			"\n"
 	      );
 	exit(0);
@@ -169,10 +169,11 @@ void process_options(int argc, char * argv[])
 			{"rx_dump", required_argument, 0, 'R'},
 			{"detailed_tx", no_argument, 0, 'T'},
 			{"stats", no_argument, 0, 's'},
-			{"stop-on-error", no_argument, 0, 'S'},
-			{"timing-byte", no_argument, 0, 'a'},
-			{"single-byte", no_argument, 0, 'z'},
+			{"stop-on-err", no_argument, 0, 'S'},
+			{"single-byte", no_argument, 0, 'y'},
+			{"second-byte", no_argument, 0, 'z'},
 			{"rts-cts", no_argument, 0, 'c'},
+			{"dump-err", no_argument, 0, 'e'},
 			{"no-rx", no_argument, 0, 'r'},
 			{"no-tx", no_argument, 0, 't'},
 			{"rx-delay", required_argument, 0, 'l'},


### PR DESCRIPTION
The help, long option names and README.md file were out of step with
each other. This aligns them so that all the option names listed in
the help are actually accepted.

The '-l' option has been omitted from the README.md file as it is not
implemented.