### PR TITLE
Fix rx-delay feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ linux-serial-test
       -r, --no-rx       Don't receive data (can be used to test flow control)
                         when serial driver buffer is full
       -t, --no-tx       Don't transmit data
+      -l, --rx-delay    Delay between reading data (ms) (can be used to test flow control)
       -q, --rs485       Enable RS485 direction control on port, and set delay
                         from when TX is finished and RS485 driver enable is
                         de-asserted. Delay is specified in bit times.
@@ -32,9 +33,22 @@ linux-serial-test
 
     linux-serial-test -s -e -p /dev/ttyO0 -b 3000000
 
-This will send full bandwidth data with a counting pattern out the TX signal.
+This will send full bandwidth data with a counting pattern on the TX signal.
 On any data received on RX, the program will look for a counting pattern and 
-report any missing data in the pattern.
+report any missing data in the pattern. This test can be done using a loopback
+cable.
+
+## Test flow control
+
+    linux-serial-test -s -e -p /dev/ttyO0 -c -l 250
+
+This enables RTS/CTS flow control and sends a counting pattern on the TX signal.
+Reads are delayed by 250ms between reads, which will cause the buffer to fill up
+and start using flow control. As before any missing data in the pattern is
+reported, and if flow control is working correctly there should be none.
+
+This test can be done using a loopback cable, or by running the program on both
+ends of the connection.
 
 ## Output a pattern where you can easily verify baud rate with scope:
 
@@ -44,5 +58,3 @@ This outputs 10 bits that are easy to measure, and then multiply by 10
 in your head to get baud rate.
 
 See the measure-baud-rate-example.png file in this project for an example.
-
-

--- a/linux-serial-test.c
+++ b/linux-serial-test.c
@@ -160,7 +160,7 @@ void process_options(int argc, char * argv[])
 {
 	for (;;) {
 		int option_index = 0;
-		static const char *short_options = "hb:p:d:R:TsSy:z:certlq:";
+		static const char *short_options = "hb:p:d:R:TsSy:z:certq:l:";
 		static const struct option long_options[] = {
 			{"help", no_argument, 0, 0},
 			{"baud", required_argument, 0, 'b'},
@@ -378,10 +378,17 @@ void setup_serial_port(int baud)
 	}
 }
 
-int diff_ms(struct timespec t1, struct timespec t2)
+int diff_ms(const struct timespec *t1, const struct timespec *t2)
 {
-    return (((t1.tv_sec - t2.tv_sec) * 1000) + 
-            (t1.tv_nsec - t2.tv_nsec))/1000000;
+	struct timespec diff;
+
+	diff.tv_sec = t1->tv_sec - t2->tv_sec;
+	diff.tv_nsec = t1->tv_nsec - t2->tv_nsec;
+	if (diff.tv_nsec < 0) {
+		diff.tv_sec--;
+		diff.tv_nsec += 1000000000;
+	}
+	return (diff.tv_sec * 1000 + diff.tv_nsec/1000000);
 }
 
 int main(int argc, char * argv[])
@@ -453,7 +460,7 @@ int main(int argc, char * argv[])
 					// since the last read
 					struct timespec current;
 					clock_gettime(CLOCK_MONOTONIC, &current);
-					if (diff_ms(current, last_read) > _cl_rx_delay) {
+					if (diff_ms(&current, &last_read) > _cl_rx_delay) {
 						process_read_data();
 						last_read = current;
 					}


### PR DESCRIPTION
Here are some corrections I made to the feature-rx-delay branch in order to make it work correctly.

* Correct the options definition because -l requires a parameter.
* Improve the diff_ms() function.
* Add documentation to the README file.