### PR TITLE
CMake: specify project type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-project (linux-serial-test)
+project(linux-serial-test C)
 cmake_minimum_required(VERSION 2.6)
 add_executable(linux-serial-test linux-serial-test.c)
 target_link_libraries(linux-serial-test rt)


### PR DESCRIPTION
We need only C compiler hence define the project type as C-only.
Otherwise CMake would probe for both C and C++ and fail on systems
with a C complier only.