### PR TITLE
linux-serial-test.c: fix missing CMSPAR define on MIPS

### DIFF
--- a/linux-serial-test.c
+++ b/linux-serial-test.c
@@ -17,6 +17,14 @@
 #include <linux/serial.h>
 #include <errno.h>
 
+/* 
+ * glibc for MIPS has its own bits/termios.h which does not define
+ * CMSPAR, so we vampirise the value from the generic bits/termios.h
+ */
+#ifndef CMSPAR
+#define CMSPAR 010000000000
+#endif
+
 // command line args
 int _cl_baud = 0;
 char *_cl_port = NULL;


### PR DESCRIPTION
This patch is an adaptation of
https://git.busybox.net/buildroot/diff/package/freerdp/0003-add-missing-define.patch?id=78cd32631e959e04b1a2f18be7b0757e21482438

linux-serial-test.c uses CMSPAR, which is defined by glibc in
bits/termios.h.

glibc has two flavours of bits/termios.h: a generic one and an
architecture-specific one. When installing, glibc will install the
architecture-specific file if it exists, otherwise it installs the
generic file. Only Alpha, MIPS, PPC and Sparc have their own
bits/termios.h.

The generic bits/termios.h, as well as the Alpha, PPC and Sparc flavours
do define CMSPAR. However, the MIPS flavour does not define it.

Define CMSPAR to the value from the generic value, which is also the
value known to the Linux kernel for MIPS.

Fixes:
 - http://autobuild.buildroot.org/results/1350cc46dcb285772b1a4c90aec6ba38fdb11e3c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>