### PR TITLE
write-follows: write only after a read and follow the count

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This is a very simple program -- there are several ways to compile it on Linux:
       -c, --rts-cts     Enable RTS/CTS flow control
       -B, --2-stop-bit  Use two stop bits per character
       -P, --parity      Use parity bit (odd, even, mark, space)
+      -k, --loopback     Use internal hardware loop back
+      -K, --write-follow Write follows the read count (can be used for multi-serial loopback)
       -e, --dump-err    Display errors
       -r, --no-rx       Don't receive data (can be used to test flow control)
                         when serial driver buffer is full


### PR DESCRIPTION
Add option to run the test as write-follow, which makes the test write follow the count of the reads. It enables a loopback to be implemented across systems.

Our use case is to have a DUT running the standard rx/tx test. The test computer runs the rx/tx with `--write-follow` enabled. With it, we can do full-duplex test instead of only rx or tx.

We fixed the spacing in "usage" to fit the added length of the option.