### PR TITLE
Error handling, updated error count and advisory Flock

### DIFF
--- a/linux-serial-test.c
+++ b/linux-serial-test.c
@@ -559,10 +559,10 @@ static void setup_serial_port(int baud)
 	}
 
 	/* Lock device file */
-	ret = flock(_fd, LOCK_EX | LOCK_NB);
-	if ((ret == -1) && (errno == EWOULDBLOCK)) {
-		perror("Device file is locked by another process");
-		exit(-EWOULDBLOCK);
+	if (flock(_fd, LOCK_EX | LOCK_NB) < 0) {
+		ret = -errno;
+		perror("Error failed to lock device file");
+		exit(ret);
 	}
 
 	bzero(&newtio, sizeof(newtio)); /* clear struct for new port settings */

--- a/linux-serial-test.c
+++ b/linux-serial-test.c
@@ -617,6 +617,17 @@ static int diff_ms(const struct timespec *t1, const struct timespec *t2)
 	return (diff.tv_sec * 1000 + diff.tv_nsec/1000000);
 }
 
+static int compute_error_count(void)
+{
+	long long int result;
+	if (_cl_no_rx == 1 || _cl_no_tx == 1)
+		result = _error_count;
+	else
+		result = llabs(_write_count - _read_count) + _error_count;
+
+	return (result > 125) ? 125 : (int)result;
+}
+
 int main(int argc, char * argv[])
 {
 	printf("Linux serial test app\n");
@@ -809,7 +820,5 @@ int main(int argc, char * argv[])
 	free(_cl_port);
 	free(_write_data);
 
-	long long int result = llabs(_write_count - _read_count) + _error_count;
-
-	return (result > 125) ? 125 : (int)result;
+	return compute_error_count();
 }

--- a/linux-serial-test.c
+++ b/linux-serial-test.c
@@ -554,7 +554,6 @@ static void setup_serial_port(int baud)
 	if (_fd < 0) {
 		ret = -errno;
 		perror("Error opening serial port");
-		free(_cl_port);
 		exit(ret);
 	}
 


### PR DESCRIPTION
# Error Handling
This MR standardizes the error handling in the serial test. At the program level, it is useful to have a return code which correspond to the errno which caused and exit condition to occur. This way, the caller can understand the cause of the failure without having to parse the strerr (particularly useful when integrated in automated tester).
Also, the errno returned is always negative, to allow differentiation with the error count returned at the end of `main`

# Updated Error Count
The returned error count didn't take into account the `no_rx` and `no_tx` options. This lead to a saturated count as soon as we where in one of those case, making the returned error count irrelevant in those cases. Again, for automatic test, it is good to be able to asses the test results from its return code.

# Advisory Flock
With an advisory flock, the program will fail early if another process holds a flock on the device file. In our workflow, it is common to be connected to a terminal on the DUT with a terminal emulator (ex.: picocom). When running linux-serial-test in conjunction, we send/receive garbage, but it is not always clear why. Having flock avoids this case since the terminal emulator also supports it.