### PR TITLE
Set c_cflag HUPCL by default to lower DTR/RTS on close

### DIFF
--- a/linux-serial-test.c
+++ b/linux-serial-test.c
@@ -679,7 +679,7 @@ static void setup_serial_port(int baud)
 	bzero(&newtio, sizeof(newtio)); /* clear struct for new port settings */
 
 	/* man termios get more info on below settings */
-	newtio.c_cflag = CS8 | CLOCAL | CREAD;
+	newtio.c_cflag = CS8 | CLOCAL | CREAD | HUPCL;
 	cfsetispeed(&newtio, baud);
 	cfsetospeed(&newtio, baud);
 


### PR DESCRIPTION
This is also the default used in the Linux kernel:
- by usb-serial.c [0]
- by tty_io.c [1]

[0] https://github.com/torvalds/linux/blob/v6.18/drivers/usb/serial/usb-serial.c#L1337-L1338
[1] https://github.com/torvalds/linux/blob/v6.18/drivers/tty/tty_io.c#L127